### PR TITLE
Fixing Auth0 vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/VeDicium/auth0-actions-sdk#readme",
   "dependencies": {
-    "auth0": "^2.39.0"
+    "auth0": "^3.0.1"
   },
   "devDependencies": {
     "@types/auth0": "^2.34.12",


### PR DESCRIPTION
According to `npm audit`, the Auth0 dependency is causing vulnerabilities. This fix moves to the latest version.